### PR TITLE
Normalizing code formatting based on actix-web style

### DIFF
--- a/examples/prost-example/src/main.rs
+++ b/examples/prost-example/src/main.rs
@@ -32,8 +32,7 @@ fn main() {
         App::new()
             .wrap(middleware::Logger::default())
             .service(web::resource("/").route(web::post().to(index)))
-    })
-    .bind("127.0.0.1:8081")
+    }).bind("127.0.0.1:8081")
     .unwrap()
     .shutdown_timeout(1)
     .start();

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 89
+reorder_imports = true


### PR DESCRIPTION
I've noticed that the formatting was a bit inconsistent so I've used actix-web's rustfmt configuration to normalize it.

It doesn't change anything functionally, but I think reformatting as a single PR should keep diffs smaller and easier to review in the future, if formatting is done alongside any feature work.