### PR TITLE
Upgrade to using actix-web 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "actix-protobuf"
 version = "0.4.1"
+edition = "2018"
 authors = ["kingxsp <jin.hb.zh@outlook.com>"]
 description = "Protobuf support for actix-web framework."
 readme = "README.md"
@@ -20,11 +21,12 @@ path = "src/lib.rs"
 
 [dependencies]
 bytes = "0.4"
-futures = "0.1"
+futures = "0.3"
 derive_more = "0.14"
 
-actix = "0.8.1"
-actix-web = "1.0.0-rc"
+actix = "0.9.0"
+actix-rt = "1.0.0"
+actix-web = "2.0.0"
 
 prost = "0.5.0"
 

--- a/examples/prost-example/src/main.rs
+++ b/examples/prost-example/src/main.rs
@@ -32,7 +32,8 @@ fn main() {
         App::new()
             .wrap(middleware::Logger::default())
             .service(web::resource("/").route(web::post().to(index)))
-    }).bind("127.0.0.1:8081")
+    })
+    .bind("127.0.0.1:8081")
     .unwrap()
     .shutdown_timeout(1)
     .start();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,8 @@ impl<T: Message + Default + 'static> Future for ProtoBufMessage<T> {
                     body.extend_from_slice(&chunk);
                     Ok(body)
                 }
-            }).and_then(|body| Ok(<T>::decode(&mut body.into_buf())?));
+            })
+            .and_then(|body| Ok(<T>::decode(&mut body.into_buf())?));
         self.fut = Some(Box::new(fut));
         self.poll()
     }
@@ -312,7 +313,8 @@ mod tests {
             .header(
                 header::CONTENT_TYPE,
                 header::HeaderValue::from_static("application/text"),
-            ).to_http_parts();
+            )
+            .to_http_parts();
         let protobuf = block_on(ProtoBufMessage::<MyObject>::new(&req, &mut pl));
         assert_eq!(protobuf.err().unwrap(), ProtoBufPayloadError::ContentType);
 
@@ -320,10 +322,12 @@ mod tests {
             .header(
                 header::CONTENT_TYPE,
                 header::HeaderValue::from_static("application/protobuf"),
-            ).header(
+            )
+            .header(
                 header::CONTENT_LENGTH,
                 header::HeaderValue::from_static("10000"),
-            ).to_http_parts();
+            )
+            .to_http_parts();
         let protobuf =
             block_on(ProtoBufMessage::<MyObject>::new(&req, &mut pl).limit(100));
         assert_eq!(protobuf.err().unwrap(), ProtoBufPayloadError::Overflow);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@ extern crate http;
 
 extern crate prost;
 #[cfg(test)]
-#[macro_use]
 extern crate prost_derive;
 
 use derive_more::Display;


### PR DESCRIPTION
This involved updating the version of futures and using modern
async/await in key parts of the implementation and tests.

The actix-web provided JSON extractor implementation was used as a
reference for the migration.  See
https://github.com/actix/actix-web/blob/master/src/types/json.rs.

This should resolve issue #7 .