### PR TITLE
bumping prost version to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,10 @@ actix = "0.9"
 actix-rt = "1"
 actix-web = "2"
 
-prost = "0.5.0"
+prost = "0.6.0"
 
 [dev-dependencies]
-prost-derive = "0.5.0"
+prost-derive = "0.6.0"
 
 [workspace]
 members = [


### PR DESCRIPTION
PR to bump the version of PROST! to the latest. Locally built and tested, everything is green